### PR TITLE
Update transformMatch.js

### DIFF
--- a/src/actions/transformMatch.js
+++ b/src/actions/transformMatch.js
@@ -225,7 +225,7 @@ function transformMatch(m) {
     }
     newPlayer.buybacks = (player.buyback_log || []).length;
     newPlayer.total_gold = (player.gold_per_min * m.duration) / 60;
-    if (m.game_mode === 18 && Object.prototype.hasOwnProperty.call(player, 'ability_upgrades_arr')) {
+    if (m.game_mode === 18 && Object.prototype.hasOwnProperty.call(player, 'ability_upgrades_arr') && player['ability_upgrades_arr']) {
       const arr = [];
       player.ability_upgrades_arr.forEach((ability) => {
         if (!arr.includes(ability) && ability < 5900) {


### PR DESCRIPTION
Added condition to check if player 'ability_upgrades_arr' isn't null. 
Ability draft matches where a player hasn't upgraded any skills aren't loading. i.e. https://www.opendota.com/matches/5310636074